### PR TITLE
Upgrade deps for java 8

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -247,7 +247,7 @@
         <artifactId>maven-scala-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
         <dependencies>
           <dependency>
@@ -308,12 +308,6 @@
               <value>${basedir}/src/test/resources/logback-test.xml</value>
             </systemProperty>
           </systemProperties>
-          <connectors>
-            <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-              <port>19093</port>
-              <maxIdleTime>60000</maxIdleTime>
-            </connector>
-          </connectors>
           <scanIntervalSeconds>600</scanIntervalSeconds>
           <stopKey>foo</stopKey>
           <stopPort>19094</stopPort>
@@ -328,7 +322,7 @@
             <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
-              <goal>run</goal>
+              <goal>start</goal>
             </goals>
             <configuration>
               <scanIntervalSeconds>0</scanIntervalSeconds>

--- a/agent/src/test/conf/jetty.xml
+++ b/agent/src/test/conf/jetty.xml
@@ -17,12 +17,21 @@
 -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <Call name="addConnector">
+    <Arg>
+      <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Set name="host">0.0.0.0</Set>
+        <Set name="port">19093</Set>
+      </New>
+    </Arg>
+  </Call>
+
   <Array id="plusConfig" type="java.lang.String">
-    <Item>org.mortbay.jetty.webapp.WebInfConfiguration</Item>
-    <Item>org.mortbay.jetty.plus.webapp.EnvConfiguration</Item>
-    <Item>org.mortbay.jetty.plus.webapp.Configuration</Item>
-    <Item>org.mortbay.jetty.webapp.JettyWebXmlConfiguration</Item>
-    <Item>org.mortbay.jetty.webapp.TagLibConfiguration</Item>
+    <Item>org.eclipse.jetty.webapp.WebInfConfiguration</Item>
+    <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
+    <Item>org.eclipse.jetty.plus.webapp.Configuration</Item>
+    <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
   </Array>
 
   <Set name="handler">
@@ -45,7 +54,7 @@
   <!-- =========================================================== -->
   <!-- Initialize the Jetty MBean container                        -->
   <!-- =========================================================== -->
-  <Get id="Container" name="container">
+  <!--<Get id="Container" name="container">
     <Call name="addEventListener">
       <Arg>
         <New class="org.eclipse.jetty.jmx.MBeanContainer">
@@ -54,7 +63,7 @@
         </New>
       </Arg>
     </Call>
-  </Get>
+  </Get>-->
 
 </Configure>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -32,6 +32,13 @@
       <type>war</type>
     </dependency>
 
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>mail</artifactId>
+      <version>1.4.1</version>
+    </dependency>
+
+
     <!-- Jetty Boot -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -69,7 +76,7 @@
     <!-- JSP resources -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-jsp-2.1</artifactId>
+      <artifactId>apache-jsp</artifactId>
       <version>${jetty.version}</version>
     </dependency>
     <dependency>

--- a/dist/src/main/assembly/jetty-bundle.xml
+++ b/dist/src/main/assembly/jetty-bundle.xml
@@ -20,7 +20,7 @@
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.1"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.1 http://maven.apache.org/xsd/assembly-1.1.1.xsd">
-
+ <id>jetty-bundle</id>
   <formats>
     <!--<format>dir</format>-->     <!-- Uncomment this when working on the packaging -->
     <format>zip</format>
@@ -104,10 +104,8 @@
       <!--<useTransitiveFiltering>true</useTransitiveFiltering>-->
       <useStrictFiltering>true</useStrictFiltering>
       <includes>
-        <include>org.eclipse.jetty:jetty-jsp-2.1</include>
+        <include>org.eclipse.jetty:apache-jsp</include>
         <include>org.eclipse.jdt.core.compiler:ecj</include>
-        <include>org.mortbay.jetty:jsp-2.1-glassfish</include>
-        <include>org.mortbay.jetty:jsp-api-2.1-glassfish</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>

--- a/dist/src/main/assembly/resources/etc/jetty.xml
+++ b/dist/src/main/assembly/resources/etc/jetty.xml
@@ -46,7 +46,6 @@
     <Item>org.mortbay.jetty.plus.webapp.EnvConfiguration</Item>
     <Item>org.mortbay.jetty.plus.webapp.Configuration</Item>
     <Item>org.mortbay.jetty.webapp.JettyWebXmlConfiguration</Item>
-    <Item>org.mortbay.jetty.webapp.TagLibConfiguration</Item>
   </Array>
 
 
@@ -123,7 +122,6 @@
         <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
         <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
         <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
-        <Item>org.eclipse.jetty.webapp.TagLibConfiguration</Item>
       </Array>
     </Set>
 
@@ -191,7 +189,6 @@
         <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
         <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
         <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
-        <Item>org.eclipse.jetty.webapp.TagLibConfiguration</Item>
       </Array>
     </Set>
 

--- a/dist/src/main/assembly/resources/etc/logback.xml
+++ b/dist/src/main/assembly/resources/etc/logback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+t?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (C) 2010-2011 LShift Ltd.
@@ -41,7 +41,7 @@
   <logger name="net.sf.ehcache" level="WARN" />
   <logger name="org.apache" level="WARN" />
   <logger name="httpclient.wire" level="WARN" />
-  <logger name="org.mortbay.log" level="WARN" />
+  <logger name="org.eclipse" level="WARN" />
   <logger name="org.quartz" level="WARN" />
   <logger name="org.exolab" level="WARN" />
   <logger name="org.codehaus" level="WARN" />

--- a/dist/src/main/assembly/resources/etc/logback.xml
+++ b/dist/src/main/assembly/resources/etc/logback.xml
@@ -1,4 +1,4 @@
-t?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (C) 2010-2011 LShift Ltd.

--- a/participants-web/pom.xml
+++ b/participants-web/pom.xml
@@ -116,7 +116,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty.version}</version>
         <dependencies>
@@ -153,6 +153,12 @@
             <artifactId>commons-io</artifactId>
             <version>${commons.io.version}</version>
           </dependency>
+
+          <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+            <version>1.4.1</version>
+          </dependency>
         </dependencies>
 
         <configuration>
@@ -171,12 +177,6 @@
               <value>http://localhost:19093/diffa-agent</value>
             </systemProperty>
           </systemProperties>
-          <connectors>
-            <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-              <port>19293</port>
-              <maxIdleTime>60000</maxIdleTime>
-            </connector>
-          </connectors>
           <scanIntervalSeconds>600</scanIntervalSeconds>
           <stopKey>foo</stopKey>
           <stopPort>19294</stopPort>
@@ -191,13 +191,12 @@
             <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
-              <goal>run</goal>
+              <goal>start</goal>
             </goals>
             <configuration>
               <jettyConfig>${basedir}/src/test/conf/jetty-test.xml</jettyConfig>
               <webAppXml>${basedir}/src/test/conf/jetty-env.xml</webAppXml>
               <scanIntervalSeconds>0</scanIntervalSeconds>
-              <daemon>true</daemon>
               <systemProperties>
                 <systemProperty>
                   <name>demo.basedir</name>

--- a/participants-web/src/test/conf/jetty-test.xml
+++ b/participants-web/src/test/conf/jetty-test.xml
@@ -17,12 +17,21 @@
 -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <Call name="addConnector">
+    <Arg>
+      <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Set name="host">0.0.0.0</Set>
+        <Set name="port">19293</Set>
+      </New>
+    </Arg>
+  </Call>
+
   <Array id="plusConfig" type="java.lang.String">
     <Item>org.eclipse.jetty.webapp.WebInfConfiguration</Item>
     <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
     <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
     <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
-    <Item>org.eclipse.jetty.webapp.TagLibConfiguration</Item>
   </Array>
 
   <Set name="handler">
@@ -52,7 +61,6 @@
             <Item>org.eclipse.jetty.webapp.WebXmlConfiguration</Item>
             <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
             <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
-            <Item>org.eclipse.jetty.webapp.TagLibConfiguration</Item>
         </Array>
     </Set>
 

--- a/participants-web/src/test/conf/jetty.xml
+++ b/participants-web/src/test/conf/jetty.xml
@@ -17,12 +17,21 @@
 -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <Call name="addConnector">
+    <Arg>
+      <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Set name="host">0.0.0.0</Set>
+        <Set name="port">19293</Set>
+      </New>
+    </Arg>
+  </Call>
+
   <Array id="plusConfig" type="java.lang.String">
-    <Item>org.mortbay.jetty.webapp.WebInfConfiguration</Item>
-    <Item>org.mortbay.jetty.plus.webapp.EnvConfiguration</Item>
-    <Item>org.mortbay.jetty.plus.webapp.Configuration</Item>
-    <Item>org.mortbay.jetty.webapp.JettyWebXmlConfiguration</Item>
-    <Item>org.mortbay.jetty.webapp.TagLibConfiguration</Item>
+    <Item>org.eclipse.jetty.webapp.WebInfConfiguration</Item>
+    <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
+    <Item>org.eclipse.jetty.plus.webapp.Configuration</Item>
+    <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
   </Array>
 
   <Set name="handler">

--- a/participants/src/main/scala/net/lshift/diffa/participants/ParticipantRpcServer.scala
+++ b/participants/src/main/scala/net/lshift/diffa/participants/ParticipantRpcServer.scala
@@ -25,7 +25,7 @@ import net.lshift.diffa.participant.common.ServletHelper
 import org.eclipse.jetty.server.handler.AbstractHandler
 import org.eclipse.jetty.security.authentication.BasicAuthenticator
 import org.eclipse.jetty.security.{HashLoginService, ConstraintMapping, ConstraintSecurityHandler}
-import org.eclipse.jetty.http.security.{Credential, Constraint}
+import org.eclipse.jetty.util.security.{Credential, Constraint}
 import org.slf4j.LoggerFactory
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <hsqldb.version>2.2.8</hsqldb.version>
     <postgresql.version>9.1-901.jdbc4</postgresql.version>
     <bonecp.version>0.7.1.RELEASE</bonecp.version>
-    <jetty.version>7.3.0.v20110203</jetty.version>
+    <jetty.version>9.3.16.v20170120</jetty.version>
     <rabbitmq.version>2.7.0</rabbitmq.version>
     <accent.version>0.9</accent.version>
     <commons.io.version>2.0.1</commons.io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -549,7 +549,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.mortbay.jetty</groupId>
+          <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
           <version>${jetty.version}</version>
         </plugin>


### PR DESCRIPTION
We formerly depended on jetty 7, which used a version of the eclipse JSP compiler that doesn't understand the java 8 classfile syntax. Most of the changes are purely fallout from that.