### PR TITLE
Package into a single uberjar that uses Jetty 9

### DIFF
--- a/adapter-support/pom.xml
+++ b/adapter-support/pom.xml
@@ -22,7 +22,7 @@
     <icu4j.version>49.1</icu4j.version>
     <junit.version>4.10</junit.version>
     <easymock.version>2.5.2</easymock.version>
-    <servlet.api.version>2.5</servlet.api.version>
+    <servlet.api.version>3.1.0</servlet.api.version>
   </properties>
 
   <licenses>
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <version>${servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -172,7 +172,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/dist/MANIFEST.MF
+++ b/dist/MANIFEST.MF
@@ -1,4 +1,4 @@
-build.jdk=${java.version}
-build.number=${build.number}
-built.by=${user.name}
-application.version=${pom.version}
+Build-Jdk=${java.version}
+Built-By=${user.name}
+Application-Version=${pom.version}
+Main-Class: org.eclipse.jetty.start.Main

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -13,6 +13,8 @@
 
   <packaging>pom</packaging>
 
+
+
   <properties>
     <assembled.filename>diffa-b${diffa.build.number}</assembled.filename>
   </properties>
@@ -53,6 +55,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlets</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>${jetty.version}</version>
     </dependency>
@@ -62,9 +69,9 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <scope>provided</scope>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-xml</artifactId>
+      <version>${jetty.version}</version>
     </dependency>
 
     <!-- JSP resources -->
@@ -74,9 +81,9 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jsp-2.1-glassfish</artifactId>
-      <version>2.1.v20100127</version>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- JNDI resources -->
@@ -101,7 +108,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-5</version>
+        <version>3.0.0</version>
         <configuration>
           <finalName>${assembled.filename}</finalName>
           <attach>false</attach>
@@ -110,7 +117,7 @@
           </descriptors>
           <archive>
             <manifest>
-              <mainClass>org.eclipse.start.Main</mainClass>
+              <mainClass>org.eclipse.jetty.start.Main</mainClass>
             </manifest>
           </archive>
         </configuration>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -73,6 +73,11 @@
       <artifactId>jetty-xml</artifactId>
       <version>${jetty.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-annotations</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
 
     <!-- JSP resources -->
     <dependency>

--- a/dist/src/main/assembly/jetty-bundle.xml
+++ b/dist/src/main/assembly/jetty-bundle.xml
@@ -59,6 +59,8 @@
         <include>org.eclipse.jetty:jetty-util</include>
         <include>org.eclipse.jetty:jetty-plus</include>
         <include>org.eclipse.jetty:jetty-jmx</include>
+        <include>org.eclipse.jetty:jetty-xml</include>
+        <include>org.eclipse.jetty:jetty-servlet</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
@@ -68,7 +70,7 @@
       <useTransitiveFiltering>false</useTransitiveFiltering>
       <useStrictFiltering>true</useStrictFiltering>
       <includes>
-        <include>javax.servlet:servlet-api</include>
+        <include>javax.servlet:javax.servlet-api</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
@@ -91,12 +93,14 @@
 
     <!-- JSP Support -->
     <dependencySet>
-      <outputDirectory>lib/jsp</outputDirectory>
+      <outputDirectory>lib/apache-jsp</outputDirectory>
       <!--<useTransitiveFiltering>true</useTransitiveFiltering>-->
       <useStrictFiltering>true</useStrictFiltering>
       <includes>
-        <include>org.eclipse.jetty:apache-jsp</include>
         <include>org.eclipse.jdt.core.compiler:ecj</include>
+        <include>org.eclipse.jetty:apache-jsp</include>
+        <include>org.mortbay.jasper:apache-jsp</include>
+        <include>org.mortbay.jasper:apache-el</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>

--- a/dist/src/main/assembly/jetty-bundle.xml
+++ b/dist/src/main/assembly/jetty-bundle.xml
@@ -22,7 +22,7 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.1 http://maven.apache.org/xsd/assembly-1.1.1.xsd">
  <id>jetty-bundle</id>
   <formats>
-    <format>dir</format>     <!-- Uncomment this when working on the packaging -->
+    <!--<format>dir</format>-->     <!-- Uncomment this when working on the packaging -->
     <format>zip</format>
   </formats>
     

--- a/dist/src/main/assembly/jetty-bundle.xml
+++ b/dist/src/main/assembly/jetty-bundle.xml
@@ -22,7 +22,7 @@
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.1 http://maven.apache.org/xsd/assembly-1.1.1.xsd">
  <id>jetty-bundle</id>
   <formats>
-    <!--<format>dir</format>-->     <!-- Uncomment this when working on the packaging -->
+    <format>dir</format>     <!-- Uncomment this when working on the packaging -->
     <format>zip</format>
   </formats>
     
@@ -61,6 +61,7 @@
         <include>org.eclipse.jetty:jetty-jmx</include>
         <include>org.eclipse.jetty:jetty-xml</include>
         <include>org.eclipse.jetty:jetty-servlet</include>
+        <include>org.eclipse.jetty:jetty-annotations</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>

--- a/dist/src/main/assembly/resources/etc/jetty-annotations.xml
+++ b/dist/src/main/assembly/resources/etc/jetty-annotations.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <!-- =========================================================== -->
+  <!-- Add annotation Configuring classes to all webapps for this Server -->
+  <!-- =========================================================== -->
+  <Call class="org.eclipse.jetty.webapp.Configuration$ClassList" name="setServerDefault">
+    <Arg><Ref refid="Server" /></Arg>
+    <Call name="addBefore">
+      <Arg name="beforeClass">org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Arg>
+      <Arg>
+        <Array type="String">
+          <Item>org.eclipse.jetty.annotations.AnnotationConfiguration</Item>
+        </Array>
+      </Arg>
+    </Call>
+  </Call>
+
+</Configure>

--- a/dist/src/main/assembly/resources/etc/jetty-http.xml
+++ b/dist/src/main/assembly/resources/etc/jetty-http.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<!-- ============================================================= -->
+<!-- Configure the Jetty Server instance with an ID "Server"       -->
+<!-- by adding a HTTP connector.                                   -->
+<!-- This configuration must be used in conjunction with jetty.xml -->
+<!-- ============================================================= -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+  <Call name="addConnector">
+    <Arg>
+      <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Set name="host">0.0.0.0</Set>
+        <Set name="port">7654</Set>
+        <Set name="idleTimeout">300000</Set>
+      </New>
+    </Arg>
+  </Call>
+
+</Configure>

--- a/dist/src/main/assembly/resources/etc/jetty-http.xml
+++ b/dist/src/main/assembly/resources/etc/jetty-http.xml
@@ -83,6 +83,39 @@
       </Arg>
     </New>
 
+    <Call name="setAttribute">
+      <Arg type="String">org.eclipse.jetty.containerInitializers</Arg>
+      <Arg>
+        <New class="java.util.ArrayList">
+          <Call name="add">
+            <Arg>
+              <New class="org.eclipse.jetty.plus.annotation.ContainerInitializer">
+                <Arg>
+                  <New class="org.eclipse.jetty.apache.jsp.JettyJasperInitializer"></New>
+                </Arg>
+                <Arg></Arg>
+              </New>
+            </Arg>
+          </Call>
+        </New>
+      </Arg>
+    </Call>
+
+    <Call name="setAttribute">
+      <Arg type="String">org.apache.tomcat.InstanceManager</Arg>
+      <Arg>
+        <New class="org.apache.tomcat.SimpleInstanceManager" />
+      </Arg>
+    </Call>
+
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.annotations.ServletContainerInitializersStarter">
+          <Arg><Ref id="webappAgent" /></Arg>
+        </New>
+      </Arg>
+    </Call>
+
   </New>
 
   <!-- 2. Boot the demo participant -->

--- a/dist/src/main/assembly/resources/etc/jetty-http.xml
+++ b/dist/src/main/assembly/resources/etc/jetty-http.xml
@@ -19,4 +19,107 @@
     </Arg>
   </Call>
 
+  <!-- 1. Boot the agent -->
+  <New id="webappAgent" class="org.eclipse.jetty.webapp.WebAppContext">
+    <Arg>
+      <Ref id="Contexts"/>
+    </Arg>
+    <Arg><SystemProperty name="diffa.home" default="."/>/webapps/root</Arg>
+    <Arg>/</Arg>
+    <Set name="ConfigurationClasses">
+      <Array type="java.lang.String">
+        <Item>org.eclipse.jetty.webapp.WebInfConfiguration</Item>
+        <Item>org.eclipse.jetty.webapp.WebXmlConfiguration</Item>
+        <Item>org.eclipse.jetty.webapp.MetaInfConfiguration</Item>
+        <Item>org.eclipse.jetty.webapp.FragmentConfiguration</Item>
+        <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
+        <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
+        <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
+      </Array>
+    </Set>
+
+    <New class="java.io.File">
+      <Arg>target/webapp-data/diffa</Arg>
+      <Get id="dbPath" name="absolutePath"/>
+    </New>
+
+    <New id="diffaDS" class="org.eclipse.jetty.plus.jndi.Resource">
+      <Arg></Arg>
+      <Arg>jdbc/diffaDS</Arg>
+      <Arg>
+        <New class="com.jolbox.bonecp.BoneCPDataSource">
+          <Arg>
+            <New class="com.jolbox.bonecp.BoneCPConfig">
+              <Set name="jdbcUrl">jdbc:hsqldb:<Ref id="dbPath"/></Set>
+            </New>
+          </Arg>
+          <Set name="driverClass">org.hsqldb.jdbc.JDBCDriver</Set>
+          <Set name="username">sa</Set>
+          <Set name="password"></Set>
+        </New>
+      </Arg>
+    </New>
+    <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
+      <Arg></Arg>
+      <Arg>diffaHibernateDialect</Arg>
+      <Arg type="java.lang.String">org.hibernate.dialect.HSQLDialect</Arg>
+      <Arg type="boolean">true</Arg>
+    </New>
+    <New id="mail" class="org.eclipse.jetty.plus.jndi.Resource">
+      <Arg>mail/Session</Arg>
+      <Arg>
+        <New class="org.eclipse.jetty.jndi.factories.MailSessionReference">
+          <Set name="user"></Set>
+          <Set name="password"></Set>
+          <Set name="properties">
+            <New class="java.util.Properties">
+              <Put name="mail.smtp.host">localhost</Put>
+              <Put name="mail.from">diffa@localhost</Put>
+              <Put name="mail.senderName">diffa Agent</Put>
+              <Put name="mail.debug">false</Put>
+            </New>
+          </Set>
+        </New>
+      </Arg>
+    </New>
+
+  </New>
+
+  <!-- 2. Boot the demo participant -->
+  <!--<New class="org.eclipse.jetty.webapp.WebAppContext">
+    <Arg>
+      <Ref id="Contexts"/>
+    </Arg>
+    <Arg>webapps/participant-demo</Arg>
+    <Arg>/participant-demo</Arg>
+
+    <Set name="ConfigurationClasses">
+      <Array type="java.lang.String">
+        <Item>org.eclipse.jetty.webapp.WebInfConfiguration</Item>
+        <Item>org.eclipse.jetty.webapp.WebXmlConfiguration</Item>
+        <Item>org.eclipse.jetty.webapp.MetaInfConfiguration</Item>
+        <Item>org.eclipse.jetty.webapp.FragmentConfiguration</Item>
+        <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
+        <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
+        <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
+      </Array>
+    </Set>
+
+    <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
+      <Arg>demoProperties</Arg>
+      <Arg>
+        <New class="java.util.Properties">
+          <Call name="load">
+            <Arg>
+              <New class="java.io.FileReader">
+                <Arg type="java.lang.String">etc/demo.properties</Arg>
+              </New>
+            </Arg>
+          </Call>
+        </New>
+      </Arg>
+    </New>
+  </New>-->
+
+
 </Configure>

--- a/dist/src/main/assembly/resources/etc/jetty-jmx.xml
+++ b/dist/src/main/assembly/resources/etc/jetty-jmx.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+  <!-- =========================================================== -->
+  <!-- Get the platform mbean server                               -->
+  <!-- =========================================================== -->
+  <Call id="MBeanServer" class="java.lang.management.ManagementFactory"
+    name="getPlatformMBeanServer" />
+
+  <!-- =========================================================== -->
+  <!-- Initialize the Jetty MBean container -->
+  <!-- =========================================================== -->
+  <Call name="addBean">
+    <Arg>
+      <New id="MBeanContainer" class="org.eclipse.jetty.jmx.MBeanContainer">
+        <Arg>
+          <Ref refid="MBeanServer" />
+        </Arg>
+      </New>
+    </Arg>
+  </Call>
+
+  <!-- Add the static log -->
+  <Call name="addBean">
+    <Arg>
+      <New class="org.eclipse.jetty.util.log.Log" />
+    </Arg>
+  </Call>
+</Configure>
+

--- a/dist/src/main/assembly/resources/etc/jetty-plus.xml
+++ b/dist/src/main/assembly/resources/etc/jetty-plus.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<!-- =============================================================== -->
+<!-- Configure extended support for webapps                          -->
+<!-- =============================================================== -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+  <!-- =========================================================== -->
+  <!-- Add plus Configuring classes to all webapps for this Server -->
+  <!-- =========================================================== -->
+  <Call class="org.eclipse.jetty.webapp.Configuration$ClassList" name="setServerDefault">
+    <Arg><Ref refid="Server" /></Arg>
+    <Call name="addAfter">
+      <Arg name="afterClass">org.eclipse.jetty.webapp.FragmentConfiguration</Arg>
+      <Arg>
+        <Array type="String">
+          <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
+          <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
+        </Array>
+      </Arg>
+    </Call>
+  </Call>
+
+</Configure>
+

--- a/dist/src/main/assembly/resources/etc/jetty.xml
+++ b/dist/src/main/assembly/resources/etc/jetty.xml
@@ -67,36 +67,6 @@
     </New>
   </Set>
 
-<!--  <Call name="addConnector">
-    <Arg>
-      <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
-        <Arg name="server"><Ref refid="Server" /></Arg>
-        <Set name="host">0.0.0.0</Set>
-        <Set name="port">7654</Set>
-        <Set name="idleTimeout">300000</Set>
-      </New>
-    </Arg>
-  </Call>-->
-
-
-  <Call id="MBeanServer" class="java.lang.management.ManagementFactory" name="getPlatformMBeanServer"/>
-
-  <!-- =========================================================== -->
-  <!-- Initialize the Jetty MBean container                        -->
-  <!-- =========================================================== -->
-  <!--<Get id="Container" name="container">
-    <Call name="addEventListener">
-      <Arg>
-        <New class="org.eclipse.jetty.jmx.MBeanContainer">
-          <Arg>
-            <Ref id="MBeanServer"/>
-          </Arg>
-          <Call name="start"/>
-        </New>
-      </Arg>
-    </Call>
-  </Get>-->
-
   <!-- =========================================================== -->
   <!-- Initialize the two web apps to run inside ths instance      -->
   <!-- of Jetty:                                                   -->
@@ -104,72 +74,6 @@
   <!-- 2. Teh demo participants application                        -->
   <!-- =========================================================== -->
 
-  <!-- 1. Boot the agent -->
-  <New class="org.eclipse.jetty.webapp.WebAppContext">
-    <Arg>
-      <Ref id="Contexts"/>
-    </Arg>
-    <Arg><SystemProperty name="diffa.home" default="."/>/webapps/root</Arg>
-    <Arg>/</Arg>
-    <Set name="ConfigurationClasses">
-      <Array type="java.lang.String">
-        <Item>org.eclipse.jetty.webapp.WebInfConfiguration</Item>
-        <Item>org.eclipse.jetty.webapp.WebXmlConfiguration</Item>
-        <Item>org.eclipse.jetty.webapp.MetaInfConfiguration</Item>
-        <Item>org.eclipse.jetty.webapp.FragmentConfiguration</Item>
-        <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
-        <Item>org.eclipse.jetty.plus.webapp.PlusConfiguration</Item>
-        <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
-      </Array>
-    </Set>
-
-
-    <New class="java.io.File">
-      <Arg>target/webapp-data/diffa</Arg>
-      <Get id="dbPath" name="absolutePath"/>
-    </New>
-
-    <New id="diffaDS" class="org.eclipse.jetty.plus.jndi.Resource">
-      <Arg></Arg>
-      <Arg>jdbc/diffaDS</Arg>
-      <Arg>
-      <New class="com.jolbox.bonecp.BoneCPDataSource">
-        <Arg>
-          <New class="com.jolbox.bonecp.BoneCPConfig">
-            <Set name="jdbcUrl">jdbc:hsqldb:<Ref id="dbPath"/></Set>
-            </New>
-          </Arg>
-          <Set name="driverClass">org.hsqldb.jdbc.JDBCDriver</Set>
-          <Set name="username">sa</Set>
-          <Set name="password"></Set>
-        </New>
-      </Arg>
-    </New>
-    <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
-      <Arg></Arg>
-      <Arg>diffaHibernateDialect</Arg>
-      <Arg type="java.lang.String">org.hibernate.dialect.HSQLDialect</Arg>
-      <Arg type="boolean">true</Arg>
-    </New>
-    <New id="mail" class="org.eclipse.jetty.plus.jndi.Resource">
-      <Arg>mail/Session</Arg>
-      <Arg>
-        <New class="org.eclipse.jetty.jndi.factories.MailSessionReference">
-          <Set name="user"></Set>
-          <Set name="password"></Set>
-          <Set name="properties">
-            <New class="java.util.Properties">
-              <Put name="mail.smtp.host">localhost</Put>
-              <Put name="mail.from">diffa@localhost</Put>
-              <Put name="mail.senderName">diffa Agent</Put>
-              <Put name="mail.debug">false</Put>
-            </New>
-          </Set>
-        </New>
-      </Arg>
-    </New>
-
-  </New>
 
   <!-- 2. Boot the demo participant -->
   <!-- <New class="org.eclipse.jetty.webapp.WebAppContext">

--- a/dist/src/main/assembly/resources/etc/jetty.xml
+++ b/dist/src/main/assembly/resources/etc/jetty.xml
@@ -34,19 +34,21 @@
     </Arg>
   </New>
 
-  <Call class="org.eclipse.jetty.util.log.Log" name="info">
-    <Arg>Redirecting Jetty stderr to<Ref id="ServerLogName"/></Arg>
-  </Call>
-  <Call class="java.lang.System" name="setErr">
+  <!--<Call class="org.eclipse.jetty.util.log.Log" name="getLog">
+    <Call class="org.eclipse.jetty.util.log.Logger" name="info">
+      <Arg>Redirecting Jetty stderr to<Ref id="ServerLogName"/></Arg>
+    </Call>
+  </Call>-->
+  <!--<Call class="java.lang.System" name="setErr">
     <Arg><Ref id="ServerLog"/></Arg>
-  </Call>
+  </Call>-->
 
   <Array id="plusConfig" type="java.lang.String">
-    <Item>org.mortbay.jetty.webapp.WebInfConfiguration</Item>
-    <Item>org.mortbay.jetty.plus.webapp.EnvConfiguration</Item>
-    <Item>org.mortbay.jetty.plus.webapp.Configuration</Item>
-    <Item>org.mortbay.jetty.webapp.JettyWebXmlConfiguration</Item>
-    <Item>org.mortbay.jetty.webapp.TagLibConfiguration</Item>
+    <Item>org.eclipse.jetty.webapp.WebInfConfiguration</Item>
+    <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
+    <Item>org.eclipse.jetty.plus.webapp.Configuration</Item>
+    <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
+    <Item>org.eclipse.jetty.webapp.TagLibConfiguration</Item>
   </Array>
 
 
@@ -65,29 +67,24 @@
     </New>
   </Set>
 
-  <Call name="addConnector">
+<!--  <Call name="addConnector">
     <Arg>
-      <New class="org.eclipse.jetty.server.nio.SelectChannelConnector">
-        <Set name="host">
-          <Property name="jetty.host"/>
-        </Set>
+      <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Set name="host">0.0.0.0</Set>
         <Set name="port">7654</Set>
-        <Set name="maxIdleTime">300000</Set>
-        <Set name="Acceptors">2</Set>
-        <Set name="statsOn">false</Set>
-        <!-- <Set name="confidentialPort">8443</Set> -->
-        <Set name="lowResourcesConnections">20000</Set>
-        <Set name="lowResourcesMaxIdleTime">5000</Set>
+        <Set name="idleTimeout">300000</Set>
       </New>
     </Arg>
-  </Call>
+  </Call>-->
+
 
   <Call id="MBeanServer" class="java.lang.management.ManagementFactory" name="getPlatformMBeanServer"/>
 
   <!-- =========================================================== -->
   <!-- Initialize the Jetty MBean container                        -->
   <!-- =========================================================== -->
-  <Get id="Container" name="container">
+  <!--<Get id="Container" name="container">
     <Call name="addEventListener">
       <Arg>
         <New class="org.eclipse.jetty.jmx.MBeanContainer">
@@ -98,7 +95,7 @@
         </New>
       </Arg>
     </Call>
-  </Get>
+  </Get>-->
 
   <!-- =========================================================== -->
   <!-- Initialize the two web apps to run inside ths instance      -->
@@ -171,7 +168,6 @@
         </New>
       </Arg>
     </New>
-
 
   </New>
 

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+maven://org.mortbay.jetty.alpn/alpn-boot/8.1.0.v20141016|lib/alpn/alpn-boot-8.1.0.v20141016.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.0.v20141016.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_05.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_05.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+maven://org.mortbay.jetty.alpn/alpn-boot/8.1.0.v20141016|lib/alpn/alpn-boot-8.1.0.v20141016.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.0.v20141016.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_101.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_101.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.9.v20160720/alpn-boot-8.1.9.v20160720.jar|lib/alpn/alpn-boot-8.1.9.v20160720.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.9.v20160720.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_102.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_102.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.9.v20160720/alpn-boot-8.1.9.v20160720.jar|lib/alpn/alpn-boot-8.1.9.v20160720.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.9.v20160720.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_11.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_11.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+maven://org.mortbay.jetty.alpn/alpn-boot/8.1.0.v20141016|lib/alpn/alpn-boot-8.1.0.v20141016.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.0.v20141016.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_111.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_111.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.9.v20160720/alpn-boot-8.1.9.v20160720.jar|lib/alpn/alpn-boot-8.1.9.v20160720.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.9.v20160720.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_112.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_112.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.10.v20161026/alpn-boot-8.1.10.v20161026.jar|lib/alpn/alpn-boot-8.1.10.v20161026.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.10.v20161026.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_121.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_121.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.11.v20170118/alpn-boot-8.1.11.v20170118.jar|lib/alpn/alpn-boot-8.1.11.v20170118.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.11.v20170118.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_20.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_20.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+maven://org.mortbay.jetty.alpn/alpn-boot/8.1.0.v20141016|lib/alpn/alpn-boot-8.1.0.v20141016.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.0.v20141016.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_25.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_25.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+maven://org.mortbay.jetty.alpn/alpn-boot/8.1.2.v20141202|lib/alpn/alpn-boot-8.1.2.v20141202.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.2.v20141202.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_31.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_31.mod
@@ -1,0 +1,8 @@
+[name]
+alpn-boot
+
+[files]
+maven://org.mortbay.jetty.alpn/alpn-boot/8.1.3.v20150130|lib/alpn/alpn-boot-8.1.3.v20150130.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.3.v20150130.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_40.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_40.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.3.v20150130/alpn-boot-8.1.3.v20150130.jar|lib/alpn/alpn-boot-8.1.3.v20150130.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.3.v20150130.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_45.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_45.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.3.v20150130/alpn-boot-8.1.3.v20150130.jar|lib/alpn/alpn-boot-8.1.3.v20150130.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.3.v20150130.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_51.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_51.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.4.v20150727/alpn-boot-8.1.4.v20150727.jar|lib/alpn/alpn-boot-8.1.4.v20150727.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.4.v20150727.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_60.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_60.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.5.v20150921/alpn-boot-8.1.5.v20150921.jar|lib/alpn/alpn-boot-8.1.5.v20150921.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.5.v20150921.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_65.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_65.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.6.v20151105/alpn-boot-8.1.6.v20151105.jar|lib/alpn/alpn-boot-8.1.6.v20151105.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.6.v20151105.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_66.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_66.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.6.v20151105/alpn-boot-8.1.6.v20151105.jar|lib/alpn/alpn-boot-8.1.6.v20151105.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.6.v20151105.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_71.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_71.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.7.v20160121/alpn-boot-8.1.7.v20160121.jar|lib/alpn/alpn-boot-8.1.7.v20160121.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.7.v20160121.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_72.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_72.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.7.v20160121/alpn-boot-8.1.7.v20160121.jar|lib/alpn/alpn-boot-8.1.7.v20160121.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.7.v20160121.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_73.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_73.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.7.v20160121/alpn-boot-8.1.7.v20160121.jar|lib/alpn/alpn-boot-8.1.7.v20160121.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.7.v20160121.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_74.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_74.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.7.v20160121/alpn-boot-8.1.7.v20160121.jar|lib/alpn/alpn-boot-8.1.7.v20160121.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.7.v20160121.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_77.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_77.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.7.v20160121/alpn-boot-8.1.7.v20160121.jar|lib/alpn/alpn-boot-8.1.7.v20160121.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.7.v20160121.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_91.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_91.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.7.v20160121/alpn-boot-8.1.7.v20160121.jar|lib/alpn/alpn-boot-8.1.7.v20160121.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.7.v20160121.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_92.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-1.8.0_92.mod
@@ -1,0 +1,8 @@
+[name]
+protonego-boot
+
+[files]
+http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/8.1.8.v20160420/alpn-boot-8.1.8.v20160420.jar|lib/alpn/alpn-boot-8.1.8.v20160420.jar
+
+[exec]
+-Xbootclasspath/p:lib/alpn/alpn-boot-8.1.8.v20160420.jar

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-8.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-8.mod
@@ -1,0 +1,30 @@
+# ALPN is provided via a -Xbootclasspath that modifies the secure connections
+# in java to support the ALPN layer needed for HTTP/2.
+#
+# This modification has a tight dependency on specific recent updates of
+# Java 1.7 and Java 1.8 (Java versions prior to 1.7u40 are not supported).
+#
+# The alpn module will use an appropriate alpn-boot jar for your
+# specific version of Java.
+#
+# IMPORTANT: Versions of Java that exist after this module was created are
+#            not guaranteed to work with existing alpn-boot jars, and might
+#            need a new alpn-boot to be created / tested / deployed by the
+#            Jetty project in order to provide support for these future
+#            Java versions.
+#
+# All versions of the alpn-boot jar can be found at
+# http://central.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/
+
+[depend]
+alpn-impl/alpn-${java.version}
+
+[files]
+lib/
+lib/alpn/
+
+[license]
+ALPN is a hosted at github under the GPL v2 with ClassPath Exception.
+ALPN replaces/modifies OpenJDK classes in the sun.security.ssl package.
+http://github.com/jetty-project/jetty-alpn
+http://openjdk.java.net/legal/gplv2+ce.html

--- a/dist/src/main/assembly/resources/modules/alpn-impl/alpn-9.mod
+++ b/dist/src/main/assembly/resources/modules/alpn-impl/alpn-9.mod
@@ -1,0 +1,5 @@
+# Provides support for ALPN based on JDK 9.
+
+[lib]
+lib/jetty-alpn-java-server-${jetty.version}.jar
+lib/alpn-api-*.jar

--- a/dist/src/main/assembly/resources/modules/alpn.mod
+++ b/dist/src/main/assembly/resources/modules/alpn.mod
@@ -1,0 +1,22 @@
+[depend]
+ssl
+alpn-impl/alpn-${java.version.platform}
+
+[lib]
+lib/jetty-alpn-client-${jetty.version}.jar
+lib/jetty-alpn-server-${jetty.version}.jar
+
+[xml]
+etc/jetty-alpn.xml
+
+[ini-template]
+## Overrides the order protocols are chosen by the server.
+## The default order is that specified by the order of the
+## modules declared in start.ini.
+# jetty.alpn.protocols=h2,http/1.1
+
+## Specifies what protocol to use when negotiation fails.
+# jetty.alpn.defaultProtocol=http/1.1
+
+## ALPN debug logging on System.err
+# jetty.alpn.debug=false

--- a/dist/src/main/assembly/resources/modules/annotations.mod
+++ b/dist/src/main/assembly/resources/modules/annotations.mod
@@ -1,0 +1,17 @@
+#
+# Jetty Annotation Scanning Module
+#
+
+[depend]
+# Annotations needs plus, and jndi features
+plus
+
+[lib]
+# Annotations needs jetty annotation jars
+lib/jetty-annotations-${jetty.version}.jar
+# Need annotation processing jars too
+lib/annotations/*.jar
+
+[xml]
+# Enable annotation scanning webapp configurations
+etc/jetty-annotations.xml

--- a/dist/src/main/assembly/resources/modules/apache-jsp.mod
+++ b/dist/src/main/assembly/resources/modules/apache-jsp.mod
@@ -1,0 +1,10 @@
+#
+# Apache JSP Module
+#
+
+[name]
+apache-jsp
+
+[lib]
+lib/apache-jsp/*.jar
+

--- a/dist/src/main/assembly/resources/modules/apache-jstl.mod
+++ b/dist/src/main/assembly/resources/modules/apache-jstl.mod
@@ -1,0 +1,9 @@
+#
+# Apache JSTL 
+#
+
+[name]
+apache-jstl
+
+[lib]
+lib/apache-jstl/*.jar

--- a/dist/src/main/assembly/resources/modules/client.mod
+++ b/dist/src/main/assembly/resources/modules/client.mod
@@ -1,0 +1,6 @@
+#
+# Client Feature
+#
+
+[lib]
+lib/jetty-client-${jetty.version}.jar

--- a/dist/src/main/assembly/resources/modules/deploy.mod
+++ b/dist/src/main/assembly/resources/modules/deploy.mod
@@ -1,0 +1,31 @@
+#
+# Deploy Feature
+#
+
+[depend]
+webapp
+
+[lib]
+lib/jetty-deploy-${jetty.version}.jar
+
+[files]
+webapps/
+
+[xml]
+etc/jetty-deploy.xml
+
+[ini-template]
+# Monitored directory name (relative to $jetty.base)
+# jetty.deploy.monitoredDir=webapps
+# - OR -
+# Monitored directory path (fully qualified)
+# jetty.deploy.monitoredPath=/var/www/webapps
+
+# Defaults Descriptor for all deployed webapps
+# jetty.deploy.defaultsDescriptorPath=${jetty.base}/etc/webdefault.xml
+
+# Monitored directory scan period (seconds)
+# jetty.deploy.scanInterval=1
+
+# Whether to extract *.war files
+# jetty.deploy.extractWars=true

--- a/dist/src/main/assembly/resources/modules/ext.mod
+++ b/dist/src/main/assembly/resources/modules/ext.mod
@@ -1,0 +1,11 @@
+#
+# Module to add all lib/ext/**.jar files to classpath
+#
+
+[lib]
+lib/ext/**.jar
+
+[files]
+lib/
+lib/ext/
+

--- a/dist/src/main/assembly/resources/modules/gzip.mod
+++ b/dist/src/main/assembly/resources/modules/gzip.mod
@@ -1,0 +1,23 @@
+#
+# GZIP module
+# Applies GzipHandler to entire server
+#
+
+[depend]
+server
+
+[xml]
+etc/jetty-gzip.xml
+
+[ini-template]
+## Minimum content length after which gzip is enabled
+# jetty.gzip.minGzipSize=2048
+
+## Check whether a file with *.gz extension exists
+# jetty.gzip.checkGzExists=false
+
+## Gzip compression level (-1 for default)
+# jetty.gzip.compressionLevel=-1
+
+## User agents for which gzip is disabled
+# jetty.gzip.excludedUserAgent=.*MSIE.6\.0.*

--- a/dist/src/main/assembly/resources/modules/home-base-warning.mod
+++ b/dist/src/main/assembly/resources/modules/home-base-warning.mod
@@ -1,0 +1,7 @@
+#
+# Home and Base Warning
+#
+
+[xml]
+etc/home-base-warning.xml
+

--- a/dist/src/main/assembly/resources/modules/http-forwarded.mod
+++ b/dist/src/main/assembly/resources/modules/http-forwarded.mod
@@ -1,0 +1,24 @@
+#
+# Jetty HTTP Connector
+#
+
+[depend]
+http
+
+[xml]
+etc/jetty-http-forwarded.xml
+
+[ini-template]
+### ForwardedRequestCustomizer Configuration
+
+# jetty.httpConfig.forwardedOnly=false
+# jetty.httpConfig.forwardedProxyAsAuthority=false
+# jetty.httpConfig.forwardedHeader=Forwarded
+# jetty.httpConfig.forwardedHostHeader=X-Forwarded-Host
+# jetty.httpConfig.forwardedServerHeader=X-Forwarded-Server
+# jetty.httpConfig.forwardedProtoHeader=X-Forwarded-Proto
+# jetty.httpConfig.forwardedForHeader=X-Forwarded-For
+# jetty.httpConfig.forwardedHttpsHeader=X-Proxied-Https
+# jetty.httpConfig.forwardedSslSessionIdHeader=Proxy-ssl-id
+# jetty.httpConfig.forwardedCipherSuiteHeader=Proxy-auth-cert
+

--- a/dist/src/main/assembly/resources/modules/http.mod
+++ b/dist/src/main/assembly/resources/modules/http.mod
@@ -1,0 +1,39 @@
+#
+# Jetty HTTP Connector
+#
+
+[depend]
+server
+
+[xml]
+etc/jetty-http.xml
+
+[ini-template]
+### HTTP Connector Configuration
+
+## Connector host/address to bind to
+# jetty.http.host=0.0.0.0
+
+## Connector port to listen on
+# jetty.http.port=8080
+
+## Connector idle timeout in milliseconds
+# jetty.http.idleTimeout=30000
+
+## Connector socket linger time in seconds (-1 to disable)
+# jetty.http.soLingerTime=-1
+
+## Number of acceptors (-1 picks default based on number of cores)
+# jetty.http.acceptors=-1
+
+## Number of selectors (-1 picks default based on number of cores)
+# jetty.http.selectors=-1
+
+## ServerSocketChannel backlog (0 picks platform default)
+# jetty.http.acceptorQueueSize=0
+
+## Thread priority delta to give to acceptor threads
+# jetty.http.acceptorPriorityDelta=0
+
+## HTTP Compliance: RFC7230, RFC2616, LEGACY
+# jetty.http.compliance=RFC7230

--- a/dist/src/main/assembly/resources/modules/http2.mod
+++ b/dist/src/main/assembly/resources/modules/http2.mod
@@ -1,0 +1,20 @@
+#
+# HTTP2 Support Module
+#
+
+[depend]
+ssl
+alpn
+
+[lib]
+lib/http2/*.jar
+
+[xml]
+etc/jetty-http2.xml
+
+[ini-template]
+## Max number of concurrent streams per connection
+# jetty.http2.maxConcurrentStreams=1024
+
+## Initial stream receive window (client to server)
+# jetty.http2.initialStreamRecvWindow=65535

--- a/dist/src/main/assembly/resources/modules/http2c.mod
+++ b/dist/src/main/assembly/resources/modules/http2c.mod
@@ -1,0 +1,22 @@
+#
+# HTTP2 Clear Text Support Module
+# This module adds support for HTTP/2 clear text to the
+# HTTP/1 clear text connector (defined in jetty-http.xml).
+# The resulting connector will accept both HTTP/1 and HTTP/2 connections.
+#
+
+[depend]
+http
+
+[lib]
+lib/http2/*.jar
+
+[xml]
+etc/jetty-http2c.xml
+
+[ini-template]
+## Max number of concurrent streams per connection
+# jetty.http2c.maxConcurrentStreams=1024
+
+## Initial stream receive window (client to server)
+# jetty.http2c.initialStreamRecvWindow=65535

--- a/dist/src/main/assembly/resources/modules/https.mod
+++ b/dist/src/main/assembly/resources/modules/https.mod
@@ -1,0 +1,14 @@
+#
+# Jetty HTTPS Connector
+#
+
+[depend]
+ssl
+
+[optional]
+http2
+http-forwarded
+
+[xml]
+etc/jetty-https.xml
+

--- a/dist/src/main/assembly/resources/modules/jamon.mod
+++ b/dist/src/main/assembly/resources/modules/jamon.mod
@@ -1,0 +1,31 @@
+#
+# JAMon Jetty module
+#
+
+[depend]
+stats
+deploy
+jmx
+jsp
+
+[xml]
+etc/jamon.xml
+
+[files]
+lib/jamon/
+maven://com.jamonapi/jamon/2.79|lib/jamon/jamon-2.79.jar
+maven://com.jamonapi/jamon_war/2.79/war|lib/jamon/jamon.war
+
+[lib]
+lib/jamon/**.jar
+
+[license]
+JAMon is a source forge hosted project released under a BSD derived license.
+http://jamonapi.sourceforge.net
+http://jamonapi.sourceforge.net/JAMonLicense.html
+
+[ini-template]
+## Jamon Configuration
+# jamon.summaryLabels=demo
+jamon.summaryLabels=default, request.getStatus().contextpath.value.ms
+

--- a/dist/src/main/assembly/resources/modules/jaspi.mod
+++ b/dist/src/main/assembly/resources/modules/jaspi.mod
@@ -1,0 +1,10 @@
+#
+# Jetty JASPI Module
+#
+
+[depend]
+security
+
+[lib]
+lib/jetty-jaspi-${jetty.version}.jar
+lib/jaspi/*.jar

--- a/dist/src/main/assembly/resources/modules/jdbc-sessions.mod
+++ b/dist/src/main/assembly/resources/modules/jdbc-sessions.mod
@@ -1,0 +1,27 @@
+#
+# Jetty JDBC Session module
+#
+
+[depend]
+annotations
+webapp
+
+[xml]
+etc/jetty-jdbc-sessions.xml
+
+
+[ini-template]
+## JDBC Session config
+
+## Unique identifier for this node in the cluster
+# jetty.jdbcSession.workerName=node1
+
+## The interval in seconds between sweeps of the scavenger
+# jetty.jdbcSession.scavenge=600
+
+## Uncomment either the datasource name or driverClass and connectionURL
+# jetty.jdbcSession.datasource=sessions
+# jetty.jdbcSession.driverClass=changeme
+# jetty.jdbcSession.connectionURL=changeme
+
+

--- a/dist/src/main/assembly/resources/modules/jmx-remote.mod
+++ b/dist/src/main/assembly/resources/modules/jmx-remote.mod
@@ -1,0 +1,16 @@
+#
+# JMX Remote Module
+#
+
+[depend]
+jmx
+
+[xml]
+etc/jetty-jmx-remote.xml
+
+[ini-template]
+## The host/address to bind RMI to
+# jetty.jmxremote.rmihost=localhost
+
+## The port RMI listens to
+# jetty.jmxremote.rmiport=1099

--- a/dist/src/main/assembly/resources/modules/jmx.mod
+++ b/dist/src/main/assembly/resources/modules/jmx.mod
@@ -1,0 +1,13 @@
+#
+# JMX Module
+#
+
+[depend]
+server
+
+[lib]
+lib/jetty-jmx-${jetty.version}.jar
+
+[xml]
+etc/jetty-jmx.xml
+

--- a/dist/src/main/assembly/resources/modules/jndi.mod
+++ b/dist/src/main/assembly/resources/modules/jndi.mod
@@ -1,0 +1,11 @@
+#
+# JNDI Support
+#
+
+[depend]
+server
+
+[lib]
+lib/jetty-jndi-${jetty.version}.jar
+lib/jndi/*.jar
+

--- a/dist/src/main/assembly/resources/modules/jsp.mod
+++ b/dist/src/main/assembly/resources/modules/jsp.mod
@@ -1,0 +1,9 @@
+#
+# Jetty JSP Module
+#
+
+[depend]
+servlet
+annotations
+apache-jsp
+

--- a/dist/src/main/assembly/resources/modules/jstl.mod
+++ b/dist/src/main/assembly/resources/modules/jstl.mod
@@ -1,0 +1,8 @@
+#
+# Jetty JSTL Module
+#
+
+[depend]
+jsp
+apache-jstl
+

--- a/dist/src/main/assembly/resources/modules/jvm.mod
+++ b/dist/src/main/assembly/resources/modules/jvm.mod
@@ -1,0 +1,22 @@
+[ini-template]
+## JVM Configuration
+## If JVM args are include in an ini file then --exec is needed
+## to start a new JVM from start.jar with the extra args.
+##
+## If you wish to avoid an extra JVM running, place JVM args
+## on the normal command line and do not use --exec
+# --exec
+# -Xmx2000m
+# -Xmn512m
+# -XX:+UseConcMarkSweepGC
+# -XX:ParallelCMSThreads=2
+# -XX:+CMSClassUnloadingEnabled
+# -XX:+UseCMSCompactAtFullCollection
+# -XX:CMSInitiatingOccupancyFraction=80
+# -verbose:gc
+# -XX:+PrintGCDateStamps
+# -XX:+PrintGCTimeStamps
+# -XX:+PrintGCDetails
+# -XX:+PrintTenuringDistribution
+# -XX:+PrintCommandLineFlags
+# -XX:+DisableExplicitGC

--- a/dist/src/main/assembly/resources/modules/logging.mod
+++ b/dist/src/main/assembly/resources/modules/logging.mod
@@ -1,0 +1,36 @@
+#
+# Jetty std err/out logging
+#
+
+[xml]
+etc/jetty-logging.xml
+
+[files]
+logs/
+
+[lib]
+lib/logging/**.jar
+resources/
+
+[ini-template]
+## Logging Configuration
+## Configure jetty logging for default internal behavior STDERR output
+# -Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
+
+## Configure jetty logging for slf4j
+# -Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.Slf4jLog
+
+## Configure jetty logging for java.util.logging
+# -Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.JavaUtilLog
+
+## Logging directory (relative to $jetty.base)
+# jetty.logging.dir=logs
+
+## Whether to append to existing file
+# jetty.logging.append=false
+
+## How many days to retain old log files
+# jetty.logging.retainDays=90
+
+## Timezone of the log timestamps
+# jetty.logging.timezone=GMT

--- a/dist/src/main/assembly/resources/modules/lowresources.mod
+++ b/dist/src/main/assembly/resources/modules/lowresources.mod
@@ -1,0 +1,28 @@
+#
+# Low Resources module
+#
+
+[depend]
+server
+
+[xml]
+etc/jetty-lowresources.xml
+
+[ini-template]
+## Scan period to look for low resources (in milliseconds)
+# jetty.lowresources.period=1000
+
+## The idle timeout to apply to low resources (in milliseconds)
+# jetty.lowresources.idleTimeout=1000
+
+## Whether to monitor ThreadPool threads for low resources
+# jetty.lowresources.monitorThreads=true
+
+## Max number of connections allowed before being in low resources mode
+# jetty.lowresources.maxConnections=0
+
+## Max memory allowed before being in low resources mode (in bytes)
+# jetty.lowresources.maxMemory=0
+
+## Max time a resource may stay in low resource mode before actions are taken (in milliseconds)
+# jetty.lowresources.maxLowResourcesTime=5000

--- a/dist/src/main/assembly/resources/modules/monitor.mod
+++ b/dist/src/main/assembly/resources/modules/monitor.mod
@@ -1,0 +1,13 @@
+#
+# Jetty Monitor module
+#
+
+[depend]
+server
+client
+
+[lib]
+lib/monitor/jetty-monitor-${jetty.version}.jar
+
+[xml]
+etc/jetty-monitor.xml

--- a/dist/src/main/assembly/resources/modules/nosql.mod
+++ b/dist/src/main/assembly/resources/modules/nosql.mod
@@ -1,0 +1,31 @@
+#
+# Jetty NoSql module
+#
+
+[depend]
+webapp
+
+[files]
+maven://org.mongodb/mongo-java-driver/2.6.1|lib/nosql/mongo-java-driver-2.6.1.jar
+
+[lib]
+lib/jetty-nosql-${jetty.version}.jar
+lib/nosql/*.jar
+
+[xml]
+etc/jetty-nosql.xml
+
+[license]
+The java driver for the MongoDB document-based database system is hosted on GitHub and released under the Apache 2.0 license.
+http://www.mongodb.org/
+http://www.apache.org/licenses/LICENSE-2.0.html
+
+[ini-template]
+## MongoDB SessionIdManager config
+
+## Unique identifier for this node in the cluster
+# jetty.nosqlSession.workerName=node1
+
+## Interval in seconds between scavenging expired sessions
+# jetty.nosqlSession.scavenge=1800
+

--- a/dist/src/main/assembly/resources/modules/plus.mod
+++ b/dist/src/main/assembly/resources/modules/plus.mod
@@ -1,0 +1,15 @@
+#
+# Jetty Plus module
+#
+
+[depend]
+server
+security
+jndi
+webapp
+
+[lib]
+lib/jetty-plus-${jetty.version}.jar
+
+[xml]
+etc/jetty-plus.xml

--- a/dist/src/main/assembly/resources/modules/proxy-protocol-ssl.mod
+++ b/dist/src/main/assembly/resources/modules/proxy-protocol-ssl.mod
@@ -1,0 +1,9 @@
+#
+# PROXY Protocol Module - SSL
+#
+
+[depend]
+ssl
+
+[xml]
+etc/jetty-proxy-protocol-ssl.xml

--- a/dist/src/main/assembly/resources/modules/proxy-protocol.mod
+++ b/dist/src/main/assembly/resources/modules/proxy-protocol.mod
@@ -1,0 +1,9 @@
+#
+# PROXY Protocol Module - HTTP
+#
+
+[depend]
+http
+
+[xml]
+etc/jetty-proxy-protocol.xml

--- a/dist/src/main/assembly/resources/modules/proxy.mod
+++ b/dist/src/main/assembly/resources/modules/proxy.mod
@@ -1,0 +1,22 @@
+#
+# Jetty Proxy module
+#
+
+[depend]
+servlet
+client
+
+[lib]
+lib/jetty-proxy-${jetty.version}.jar
+
+[xml]
+etc/jetty-proxy.xml
+
+[ini-template]
+## Proxy Configuration
+# jetty.proxy.servletClass=org.eclipse.jetty.proxy.ProxyServlet
+# jetty.proxy.servletMapping=/*
+# jetty.proxy.maxThreads=128
+# jetty.proxy.maxConnections=256
+# jetty.proxy.idleTimeout=30000
+# jetty.proxy.timeout=60000

--- a/dist/src/main/assembly/resources/modules/requestlog.mod
+++ b/dist/src/main/assembly/resources/modules/requestlog.mod
@@ -1,0 +1,40 @@
+#
+# Request Log module
+#
+
+[depend]
+server
+
+[xml]
+etc/jetty-requestlog.xml
+
+[files]
+logs/
+
+[ini-template]
+## Logging directory (relative to $jetty.base)
+# jetty.requestlog.dir=logs
+
+## File path
+# jetty.requestlog.filePath=${jetty.requestlog.dir}/yyyy_mm_dd.request.log
+
+## Date format for rollovered files (uses SimpleDateFormat syntax)
+# jetty.requestlog.filenameDateFormat=yyyy_MM_dd
+
+## How many days to retain old log files
+# jetty.requestlog.retainDays=90
+
+## Whether to append to existing file
+# jetty.requestlog.append=true
+
+## Whether to use the extended log output
+# jetty.requestlog.extended=true
+
+## Whether to log http cookie information
+# jetty.requestlog.cookies=true
+
+## Timezone of the log entries
+# jetty.requestlog.timezone=GMT
+
+## Whether to log LogLatency
+# jetty.requestlog.loglatency=false

--- a/dist/src/main/assembly/resources/modules/resources.mod
+++ b/dist/src/main/assembly/resources/modules/resources.mod
@@ -1,0 +1,10 @@
+#
+# Module to add resources directory to classpath
+#
+
+[lib]
+resources/
+
+[files]
+resources/
+

--- a/dist/src/main/assembly/resources/modules/rewrite-compactpath.mod
+++ b/dist/src/main/assembly/resources/modules/rewrite-compactpath.mod
@@ -1,0 +1,10 @@
+#
+# Jetty Rewrite CompactPath module
+#
+[xml]
+etc/rewrite-compactpath.xml
+
+[ini-template]
+## Requires either rewrite or rewrite-customizer module
+## with rewritePathInfo==true
+jetty.rewrite.rewritePathInfo=true

--- a/dist/src/main/assembly/resources/modules/rewrite-customizer.mod
+++ b/dist/src/main/assembly/resources/modules/rewrite-customizer.mod
@@ -1,0 +1,24 @@
+#
+# Jetty Rewrite Customizer module
+#
+# Apply rewrite rules as a request customizer applied to all
+# connectors sharing a HttpConfiguration
+#
+[depend]
+server
+
+[lib]
+lib/jetty-rewrite-${jetty.version}.jar
+
+[xml]
+etc/jetty-rewrite-customizer.xml
+
+[ini-template]
+## Whether to rewrite the request URI
+# jetty.rewrite.rewriteRequestURI=true
+
+## Whether to rewrite the path info
+# jetty.rewrite.rewritePathInfo=true
+
+## Request attribute key under with the original path is stored
+# jetty.rewrite.originalPathAttribute=requestedPath

--- a/dist/src/main/assembly/resources/modules/rewrite.mod
+++ b/dist/src/main/assembly/resources/modules/rewrite.mod
@@ -1,0 +1,23 @@
+#
+# Jetty Rewrite module
+#
+# Install rewrite rules as a handler applied to all requests on a server
+#
+[depend]
+server
+
+[lib]
+lib/jetty-rewrite-${jetty.version}.jar
+
+[xml]
+etc/jetty-rewrite.xml
+
+[ini-template]
+## Whether to rewrite the request URI
+# jetty.rewrite.rewriteRequestURI=true
+
+## Whether to rewrite the path info
+# jetty.rewrite.rewritePathInfo=false
+
+## Request attribute key under with the original path is stored
+# jetty.rewrite.originalPathAttribute=requestedPath

--- a/dist/src/main/assembly/resources/modules/security.mod
+++ b/dist/src/main/assembly/resources/modules/security.mod
@@ -1,0 +1,9 @@
+#
+# Jetty Security Module
+#
+
+[depend]
+server
+
+[lib]
+lib/jetty-security-${jetty.version}.jar

--- a/dist/src/main/assembly/resources/modules/server.mod
+++ b/dist/src/main/assembly/resources/modules/server.mod
@@ -1,0 +1,82 @@
+#
+# Base Server Module
+#
+
+[optional]
+jvm
+ext
+resources
+
+[lib]
+lib/servlet-api-3.1.jar
+lib/jetty-schemas-3.1.jar
+lib/jetty-http-${jetty.version}.jar
+lib/jetty-server-${jetty.version}.jar
+lib/jetty-xml-${jetty.version}.jar
+lib/jetty-util-${jetty.version}.jar
+lib/jetty-io-${jetty.version}.jar
+
+[xml]
+etc/jetty.xml
+
+[ini-template]
+### ThreadPool configuration
+## Minimum number of threads
+# jetty.threadPool.minThreads=10
+
+## Maximum number of threads
+# jetty.threadPool.maxThreads=200
+
+## Thread idle timeout (in milliseconds)
+# jetty.threadPool.idleTimeout=60000
+
+### Common HTTP configuration
+## Scheme to use to build URIs for secure redirects
+# jetty.httpConfig.secureScheme=https
+
+## Port to use to build URIs for secure redirects
+# jetty.httpConfig.securePort=8443
+
+## Response content buffer size (in bytes)
+# jetty.httpConfig.outputBufferSize=32768
+
+## Max response content write length that is buffered (in bytes)
+# jetty.httpConfig.outputAggregationSize=8192
+
+## Max request headers size (in bytes)
+# jetty.httpConfig.requestHeaderSize=8192
+
+## Max response headers size (in bytes)
+# jetty.httpConfig.responseHeaderSize=8192
+
+## Whether to send the Server: header
+# jetty.httpConfig.sendServerVersion=true
+
+## Whether to send the Date: header
+# jetty.httpConfig.sendDateHeader=false
+
+## Max per-connection header cache size (in nodes)
+# jetty.httpConfig.headerCacheSize=512
+
+## Whether, for requests with content, delay dispatch until some content has arrived
+# jetty.httpConfig.delayDispatchUntilContent=true
+
+## Maximum number of error dispatches to prevent looping
+# jetty.httpConfig.maxErrorDispatches=10
+
+## Maximum time to block in total for a blocking IO operation (default -1 is to use idleTimeout on progress)
+# jetty.httpConfig.blockingTimeout=-1
+
+### Server configuration
+## Whether ctrl+c on the console gracefully stops the Jetty server
+# jetty.server.stopAtShutdown=true
+
+## Timeout in ms to apply when stopping the server gracefully
+# jetty.server.stopTimeout=5000
+
+## Dump the state of the Jetty server, components, and webapps after startup
+# jetty.server.dumpAfterStart=false
+
+## Dump the state of the Jetty server, components, and webapps before shutdown
+# jetty.server.dumpBeforeStop=false
+

--- a/dist/src/main/assembly/resources/modules/servlet.mod
+++ b/dist/src/main/assembly/resources/modules/servlet.mod
@@ -1,0 +1,10 @@
+#
+# Jetty Servlet Module
+#
+
+[depend]
+server
+
+[lib]
+lib/jetty-servlet-${jetty.version}.jar
+lib/javax.servlet-api-*.jar

--- a/dist/src/main/assembly/resources/modules/servlets.mod
+++ b/dist/src/main/assembly/resources/modules/servlets.mod
@@ -1,0 +1,11 @@
+#
+# Jetty Servlets Module
+#
+
+
+[depend]
+servlet
+
+[lib]
+lib/jetty-servlets-${jetty.version}.jar
+

--- a/dist/src/main/assembly/resources/modules/setuid.mod
+++ b/dist/src/main/assembly/resources/modules/setuid.mod
@@ -1,0 +1,19 @@
+#
+# Set UID Feature
+#
+
+[depend]
+server
+
+[lib]
+lib/setuid/jetty-setuid-java-1.0.3.jar
+
+[xml]
+etc/jetty-setuid.xml
+
+[ini-template]
+## SetUID Configuration
+# jetty.setuid.startServerAsPrivileged=false
+# jetty.setuid.userName=jetty
+# jetty.setuid.groupName=jetty
+# jetty.setuid.umask=002

--- a/dist/src/main/assembly/resources/modules/spring.mod
+++ b/dist/src/main/assembly/resources/modules/spring.mod
@@ -1,0 +1,17 @@
+#
+# Spring
+#
+
+[name]
+spring
+
+[depend]
+server
+
+[lib]
+lib/spring/*.jar
+
+[ini-template]
+## See http://www.eclipse.org/jetty/documentation/current/frameworks.html#framework-jetty-spring
+## for information on how to complete spring configuration
+

--- a/dist/src/main/assembly/resources/modules/ssl.mod
+++ b/dist/src/main/assembly/resources/modules/ssl.mod
@@ -1,0 +1,97 @@
+#
+# SSL Keystore module
+#
+
+[name]
+ssl
+
+[depend]
+server
+
+[xml]
+etc/jetty-ssl.xml
+etc/jetty-ssl-context.xml
+
+[files]
+https://raw.githubusercontent.com/eclipse/jetty.project/master/jetty-server/src/test/config/etc/keystore?id=${jetty.tag.version}|etc/keystore
+
+[ini-template]
+### TLS(SSL) Connector Configuration
+
+## Connector host/address to bind to
+# jetty.ssl.host=0.0.0.0
+
+## Connector port to listen on
+# jetty.ssl.port=8443
+
+## Connector idle timeout in milliseconds
+# jetty.ssl.idleTimeout=30000
+
+## Connector socket linger time in seconds (-1 to disable)
+# jetty.ssl.soLingerTime=-1
+
+## Number of acceptors (-1 picks default based on number of cores)
+# jetty.ssl.acceptors=-1
+
+## Number of selectors (-1 picks default based on number of cores)
+# jetty.ssl.selectors=-1
+
+## ServerSocketChannel backlog (0 picks platform default)
+# jetty.ssl.acceptorQueueSize=0
+
+## Thread priority delta to give to acceptor threads
+# jetty.ssl.acceptorPriorityDelta=0
+
+## Whether request host names are checked to match any SNI names
+# jetty.ssl.sniHostCheck=true
+
+## max age in seconds for a Strict-Transport-Security response header (default -1)
+# jetty.ssl.stsMaxAgeSeconds=31536000
+
+## include subdomain property in any Strict-Transport-Security header (default false)
+# jetty.ssl.stsIncludeSubdomains=true
+
+### SslContextFactory Configuration
+## Note that OBF passwords are not secure, just protected from casual observation
+## See http://www.eclipse.org/jetty/documentation/current/configuring-security-secure-passwords.html
+
+## Keystore file path (relative to $jetty.base)
+# jetty.sslContext.keyStorePath=etc/keystore
+
+## Truststore file path (relative to $jetty.base)
+# jetty.sslContext.trustStorePath=etc/keystore
+
+## Keystore password
+# jetty.sslContext.keyStorePassword=OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4
+
+## Keystore type and provider
+# jetty.sslContext.keyStoreType=JKS
+# jetty.sslContext.keyStoreProvider=
+
+## KeyManager password
+# jetty.sslContext.keyManagerPassword=OBF:1u2u1wml1z7s1z7a1wnl1u2g
+
+## Truststore password
+# jetty.sslContext.trustStorePassword=OBF:1vny1zlo1x8e1vnw1vn61x8g1zlu1vn4
+
+## Truststore type and provider
+# jetty.sslContext.trustStoreType=JKS
+# jetty.sslContext.trustStoreProvider=
+
+## whether client certificate authentication is required
+# jetty.sslContext.needClientAuth=false
+
+## Whether client certificate authentication is desired
+# jetty.sslContext.wantClientAuth=false
+
+## Whether cipher order is significant (since java 8 only)
+# jetty.sslContext.useCipherSuitesOrder=true
+
+## To configure Includes / Excludes for Cipher Suites or Protocols see tweak-ssl.xml example at
+## https://www.eclipse.org/jetty/documentation/current/configuring-ssl.html#configuring-sslcontextfactory-cipherSuites
+
+## Set the size of the SslSession cache
+# jetty.sslContext.sslSessionCacheSize=-1
+
+## Set the timeout (in seconds) of the SslSession cache timeout
+# jetty.sslContext.sslSessionTimeout=-1

--- a/dist/src/main/assembly/resources/modules/stats.mod
+++ b/dist/src/main/assembly/resources/modules/stats.mod
@@ -1,0 +1,9 @@
+#
+# Stats module
+#
+
+[depend]
+server
+
+[xml]
+etc/jetty-stats.xml

--- a/dist/src/main/assembly/resources/modules/webapp.mod
+++ b/dist/src/main/assembly/resources/modules/webapp.mod
@@ -1,0 +1,10 @@
+#
+# WebApp Support Module
+#
+
+[depend]
+servlet
+security
+
+[lib]
+lib/jetty-webapp-${jetty.version}.jar

--- a/dist/src/main/assembly/resources/modules/websocket.mod
+++ b/dist/src/main/assembly/resources/modules/websocket.mod
@@ -1,0 +1,12 @@
+#
+# WebSocket Module
+#
+
+[depend]
+# javax.websocket needs annotations
+annotations
+
+[lib]
+lib/websocket/*.jar
+
+

--- a/dist/src/main/assembly/resources/start.ini
+++ b/dist/src/main/assembly/resources/start.ini
@@ -2,3 +2,6 @@
 --module=server
 --module=http
 --module=jsp
+--module=jmx
+--module=annotations
+--module=plus

--- a/dist/src/main/assembly/resources/start.ini
+++ b/dist/src/main/assembly/resources/start.ini
@@ -1,2 +1,4 @@
 -Dlogback.configurationFile=etc/logback.xml
-OPTIONS=All
+--module=server
+--module=http
+--module=jsp

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -132,7 +132,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <guava.version>11.0.1</guava.version>
     <zookeeper.version>3.4.6</zookeeper.version>
     <scalatest.version>2.2.6</scalatest.version>
+    <servlet.api.version>3.1.0</servlet.api.version>
   </properties>
 
   <scm>
@@ -464,8 +465,8 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>${servlet.api.version}</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
Jetty modules are no longer configured through OPTIONS. Instead,
one has to provide confs in modules directory for it to boot up.
Also, at the beginning only server, http and jsp modules are enabled
(I see no point for more).

I also needed to adapt a few dependecies.